### PR TITLE
🚨Fix privacy for external links

### DIFF
--- a/layouts/community/section.html
+++ b/layouts/community/section.html
@@ -125,6 +125,7 @@
             <a
               href="https://join.slack.com/t/kalkspacecommunity/shared_invite/enQtNzg3NDg2MTMyMDgwLWRmODI3OGQzODM4NGQ5M2I3YjhmZDI5ODE0ZmE5YjkwOTVlNTE1Y2MzYTM0NDk4NGM5YzZmMzU1NDBiY2JmNWM"
               target="_blank"
+              rel="noreferrer"
               >Sprich direkt mit der Community via Slack</a
             >
           </wired-button>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -5,19 +5,20 @@
     {{ else }}
     <a href="/" title="Zur Startseite"><strong>KalkSpace.</strong></a>
     {{ end }}
-    <a href="https://g.page/kalkspace?share" target="_blank">Olpener Str. 33</a>
+    <a href="https://g.page/kalkspace?share" target="_blank" rel="noreferrer">Olpener Str. 33</a>
   </span>
   <div class="d-flex flex-md-row flex-column">
     <a href="https://discuss.kalk.space/" target="_blank" class="ml-4">Forum</a>
-    <a href="https://www.instagram.com/kalk.space/" target="_blank" class="ml-4"
+    <a href="https://www.instagram.com/kalk.space/" target="_blank" rel="noreferrer" class="ml-4"
       >Instagram</a
     >
-    <a href="https://twitter.com/kalkspace" target="_blank" class="ml-4"
+    <a href="https://twitter.com/kalkspace" target="_blank" rel="noreferrer" class="ml-4"
       >Twitter</a
     >
     <a
       href="https://join.slack.com/t/kalkspacecommunity/shared_invite/enQtNzg3NDg2MTMyMDgwLWRmODI3OGQzODM4NGQ5M2I3YjhmZDI5ODE0ZmE5YjkwOTVlNTE1Y2MzYTM0NDk4NGM5YzZmMzU1NDBiY2JmNWM"
       target="_blank"
+      rel="noreferrer"
       class="ml-4"
       >Slack</a
     >

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -9,6 +9,7 @@
     href="https://shop.spreadshirt.de/kalkspace"
     title="Zum KalkSpace Shop"
     target="_blank"
+    rel="noreferrer"
     >Merch</a
   >
 </nav>

--- a/layouts/partials/home/foerder.html
+++ b/layouts/partials/home/foerder.html
@@ -14,7 +14,7 @@
       />
       <p>
         Unsere Freund*innen von
-        <a href="https://www.railslove.com/" target="_blank">Railslove</a> haben
+        <a href="https://www.railslove.com/" target="_blank" rel="noreferrer">Railslove</a> haben
         schon früh an unsere Ideen geglaubt und unterstützen uns seitdem auf
         ganzer Linie. Danke!
       </p>
@@ -28,7 +28,7 @@
       />
       <p>
         Dank
-        <a href="https://www.stormforger.com/" target="_blank">StormForger</a>
+        <a href="https://www.stormforger.com/" target="_blank" rel="noreferrer">StormForger</a>
         haben wir einen vernünftigen Drucker in unserem Space.
       </p>
     </div>

--- a/layouts/partials/home/news.html
+++ b/layouts/partials/home/news.html
@@ -14,7 +14,7 @@
             Am 21.03. veranstalten wir im KalkSpace einen Workshop, bei dem du innerhalb eines Tages eine komplette Webseite baust. DjangoGirls ist ein kostenloser Programmierworkshop für Mädchen, Frauen, Non-binäre, Trans und Inter Personen. Du lernst HTML, CSS, die Programmiersprache Python und das Webframework Django kennen. Kein Vorwissen nötig, nur ein Laptop.
           </p>
           <p>
-            Anmeldung hier: <a href='http://djangogirls.org/koln/'>http://djangogirls.org/koln/</a>
+            Anmeldung hier: <a href='http://djangogirls.org/koln/' rel="noreferrer">http://djangogirls.org/koln/</a>
           </p>
         </div>
         <div class="d-flex justify-content-center">
@@ -30,7 +30,7 @@
           <p>
             Neben Teilnehmenden suchen wir auch Mentor:innen! Meldet euch gerne, auch wenn ihr normalerweise kein Python schreibt. Wir machen vorher einen kleinen Workshop zur Vorbereitung.
             Schreibe uns, wenn du dabei sein möchtest.
-            <p>Schreib uns hier: <a href="https://djangogirls.org/contact/">Mentor:in werden</a>
+            <p>Schreib uns hier: <a href="https://djangogirls.org/contact/" rel="noreferrer">Mentor:in werden</a>
             </p>
           </p>
         </div>


### PR DESCRIPTION
Prevent external pages from accessing `window.opener`,
also suppress `Referer` header for privacy.

Ref: https://developers.google.com/web/tools/lighthouse/audits/noopener